### PR TITLE
Make task an optional field in agents with validation for presence in either agent or pilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 dist/
 .vscode/
 /test.py
+/main.py

--- a/pilottai/agent/agent.py
+++ b/pilottai/agent/agent.py
@@ -91,12 +91,13 @@ class Agent(BaseAgent):
 
     def _verify_tasks(self, tasks):
         tasks_obj = None
-        if isinstance(tasks, str):
-            tasks_obj = [TaskUtility.to_task(tasks)]
-        elif isinstance(tasks, Task):
-            tasks_obj = [TaskUtility.to_task(tasks)]
-        elif isinstance(tasks, list):
-            tasks_obj = TaskUtility.to_task_list(tasks)
+        try:
+            if isinstance(tasks, str) or isinstance(tasks, Task):
+                tasks_obj = [TaskUtility.to_task(tasks)]
+            elif isinstance(tasks, list):
+                tasks_obj = TaskUtility.to_task_list(tasks)
+        except:
+            raise ValueError(f"Cannot convert {type(tasks)} to Task. Must be a string, dictionary, or Task object.")
         return tasks_obj
 
     async def execute_tasks(self) -> List[TaskResult]:

--- a/pilottai/agent/agent.py
+++ b/pilottai/agent/agent.py
@@ -26,7 +26,7 @@ class Agent(BaseAgent):
         role: str,
         goal: str,
         description: str,
-        tasks: Union[str, Task, List[str], List[Task]],
+        tasks: Optional[Union[str, Task, List[str], List[Task]]] = None,
         tools: Optional[List[Tool]] = None,
         source: Optional[DataManager] = None,
         config: Optional[AgentConfig] = None,
@@ -92,7 +92,9 @@ class Agent(BaseAgent):
     def _verify_tasks(self, tasks):
         tasks_obj = None
         if isinstance(tasks, str):
-            tasks_obj = TaskUtility.to_task(tasks)
+            tasks_obj = [TaskUtility.to_task(tasks)]
+        elif isinstance(tasks, Task):
+            tasks_obj = [TaskUtility.to_task(tasks)]
         elif isinstance(tasks, list):
             tasks_obj = TaskUtility.to_task_list(tasks)
         return tasks_obj

--- a/pilottai/agent/agent.py
+++ b/pilottai/agent/agent.py
@@ -26,7 +26,7 @@ class Agent(BaseAgent):
         role: str,
         goal: str,
         description: str,
-        tasks: Union[str, Task, List[str], List[Task]],
+        tasks: Optional[Union[str, Task, List[str], List[Task]]] = None,
         tools: Optional[List[Tool]] = None,
         source: Optional[DataManager] = None,
         config: Optional[AgentConfig] = None,
@@ -88,6 +88,9 @@ class Agent(BaseAgent):
 
         # Setup logging
         self.logger = self._setup_logger()
+
+    def __len__(self):
+        return len(self.tasks) if self.tasks else 0
 
     def _verify_tasks(self, tasks):
         tasks_obj = None

--- a/pilottai/agent/agent.py
+++ b/pilottai/agent/agent.py
@@ -26,7 +26,7 @@ class Agent(BaseAgent):
         role: str,
         goal: str,
         description: str,
-        tasks: Optional[Union[str, Task, List[str], List[Task]]] = None,
+        tasks: Union[str, Task, List[str], List[Task]],
         tools: Optional[List[Tool]] = None,
         source: Optional[DataManager] = None,
         config: Optional[AgentConfig] = None,

--- a/pilottai/pilott.py
+++ b/pilottai/pilott.py
@@ -65,6 +65,13 @@ class Pilott:
         # Setup logging
         self.logger = self._setup_logger()
 
+        all_agents = self.agents + ([self.master_agent] if self.master_agent else [])
+        if len(self) == 0 and not any(len(agent) > 0 for agent in all_agents):
+            raise ValueError("At least a single task must be provided in either Pilott or at least one Agent.")
+
+    def __len__(self):
+        return len(self.tasks) if self.tasks else 0
+
     def _verify_tasks(self, tasks):
         tasks_obj = None
         if isinstance(tasks, str):

--- a/pilottai/utils/task_utils.py
+++ b/pilottai/utils/task_utils.py
@@ -25,17 +25,17 @@ class TaskUtility:
             ValueError: If the input cannot be converted to a Task
         """
         if isinstance(task_input, Task):
-            return [task_input]
+            return task_input
 
         elif isinstance(task_input, str):
-            return [Task(description=task_input)]
+            return Task(description=task_input)
 
         elif isinstance(task_input, dict):
             # Ensure the dictionary has at least a description
             if "description" not in task_input:
                 raise ValueError("Task dictionary must contain a 'description' field")
 
-            return [Task(**task_input)]
+            return Task(**task_input)
 
         else:
             raise ValueError(
@@ -58,9 +58,7 @@ class TaskUtility:
 
         # Handle lists
         elif isinstance(task_inputs, list):
-            task_list = []
-            task_list.extend(TaskUtility.to_task(item) for item in task_inputs)
-            return task_list
+            return [TaskUtility.to_task(item) for item in task_inputs]
 
         else:
             raise ValueError(f"Cannot convert {type(task_inputs)} to a list of Tasks")

--- a/tests/test_pilott.py
+++ b/tests/test_pilott.py
@@ -10,6 +10,7 @@ from pilottai.core import BaseAgent, LLMConfig
 from pilottai.core.task import Task, TaskResult
 from pilottai.enums.process_e import ProcessType
 from pilottai.enums.task_e import TaskPriority, TaskAssignmentType
+from pilottai.utils.task_utils import TaskUtility
 
 
 @pytest.fixture
@@ -86,6 +87,34 @@ async def pilott():
         yield pilott_instance
     finally:
         await pilott_instance.stop()
+
+
+@pytest.fixture
+def task_description():
+    """Fixture to create a string input task"""
+    return "This is a task"
+
+
+@pytest.fixture
+def task_fixture():
+    """Fixture to create a task object"""
+    return Task(id="t1", description="Sample task")
+
+
+@pytest.fixture
+def string_task_list():
+    """Fixture to create a list of string input tasks"""
+    return ["Write docs", "Refactor code", "Push to GitHub"]
+
+
+@pytest.fixture
+def task_object_list():
+    """Fixture to create a list of input task objects"""
+    return [
+        Task(id="a1", description="First"),
+        Task(id="a2", description="Second"),
+        Task(id="a3", description="Third")
+    ]
 
 
 class TestPilott:
@@ -259,3 +288,36 @@ class TestPilott:
         assert "total_tasks" in metrics
         assert metrics["total_tasks"] == 0
         assert "is_running" in metrics
+
+
+    def test_to_task_with_string_input(self, task_description):
+        """Test to_task using string input"""
+        result = TaskUtility.to_task(task_description)
+        assert isinstance(result, Task)
+        assert result.description == task_description
+        assert isinstance(result.id, str)
+        assert result.status.name == "PENDING"
+
+
+    def test_to_task_with_task_object(self, task_fixture):
+        """Test to_task using task object input"""
+        result = TaskUtility.to_task(task_fixture)
+        assert result == task_fixture
+
+
+    def test_to_task_list_with_list_of_strings(self, string_task_list):
+        """Test to_task_list using list of strings input"""
+        result = TaskUtility.to_task_list(string_task_list)
+        assert isinstance(result, list)
+        assert len(result) == len(string_task_list)
+        for task, expected_desc in zip(result, string_task_list):
+            assert isinstance(task, Task)
+            assert task.description == expected_desc
+
+
+    def test_to_task_list_with_list_of_tasks(self, task_object_list):
+        """Test to_task_list using list of task objects input"""
+        result = TaskUtility.to_task_list(task_object_list)
+        assert len(result) == len(task_object_list)
+        for t1, t2 in zip(result, task_object_list):
+            assert t1 == t2


### PR DESCRIPTION
1. Made the task field as optional in agents.
2. Added a check to ensure that at least one task is provided either in the pilott or the agent. If not, a ValueError is raised.
3. Added test cases to check different valid task input scenarios.